### PR TITLE
Extend open UDP port range.

### DIFF
--- a/security_groups.tf
+++ b/security_groups.tf
@@ -39,8 +39,8 @@ resource "aws_security_group" "allow_connections_jitsi-meet" {
     cidr_blocks = ["0.0.0.0/0"]
   }
   egress {
-    from_port   = 53
-    to_port     = 53
+    from_port   = 0
+    to_port     = 65535
     protocol    = "udp"
     cidr_blocks = ["0.0.0.0/0"]
   }


### PR DESCRIPTION
The default script worked for starting a Jitsi instance, but it would fail when more than 2 people joined.
From the related search results, it appears the videobridge service requires a wider range of outbound ports. 

After making this change, it worked well for me.

